### PR TITLE
Add biolink_model_pydantic to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
         'pandas',
         'networkx',
         'kghub-downloader',
-        'koza'
+        'koza',
+        'biolink_model_pydantic'
     ],
     extras_require=extras,
 )


### PR DESCRIPTION
It looks like `biolink_model_pydantic` is a dependency required by the transform step but not specified in setup.py.

This PR just adds the missing dependency to setup.py