### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:latest
+
+# Install packages
+RUN apt-get update && apt-get install -y build-essential openjdk-18-jdk git-core python3-dev python3-pip
+
+# Copy contents of repository to container
+COPY . /src
+
+# Set work directory in container
+WORKDIR /src
+
+# Install Python dependencies
+RUN pip install -e .
+
+ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Download-Transform-Merge Template
 ================================================
-KG hub template for tools to generate knowledge graphs for projects
+KG-Hub template for tools to generate knowledge graphs for projects
 
 Documentation
 ------------------------------------------------
@@ -28,6 +28,24 @@ Thes examples have download links and transform codes from other projects.
 
 The [merge.yaml](merge.yaml) shows merging of the various KGs. In this example we have ENVO, CHEBI, NCBITaxon and the Traits KGs merged.
 
-**Implementation**
+**Usage**
 
 [Use this template](https://github.com/Knowledge-Graph-Hub/kg-dtm-template/generate) to generate a template in the desired repository and then refactor the string `project_name` in the project to the desired project name. 
+
+*Running in a container*: the Dockerfile in this directory will set up a Docker container for running the code in this repository. This may help if you experience any issues running the template in your software environment (e.g., if you're using Windows or can't update your Python version). Ensure Docker is installed, then from your own clone of this repository, run the following:
+
+```
+docker build -t "kg-dtm:Dockerfile" .
+```
+
+You should then see the new image when you run
+
+```
+docker images
+```
+
+Then enter it with the following command and continue on your KG assembly journey.
+
+```
+docker run -it kg-dtm bash
+```


### PR DESCRIPTION
This PR adds a simple Dockerfile that creates a self-contained environment for running the transformations defined in the template.

The Dockerfile is an alternative for users who are having trouble setting up the template for their needs or using an OS that is giving issues w.r.t. certain dependencies (Python, Java, shell, etc.)

The idea of a Dockerfile came after a discussion with @k-c-martin, who was having trouble adapting the template for her KG project on Windows.
